### PR TITLE
Store models locally WIP

### DIFF
--- a/app/assets/javascripts/organizations.js.coffee
+++ b/app/assets/javascripts/organizations.js.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/organizations.css.scss
+++ b/app/assets/stylesheets/organizations.css.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the organizations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -6,7 +6,7 @@ class IssuesController < ApplicationController
 
   def index
     @project.repositories.each do |repo|
-      repo.regenerate_issues(github_client)
+      repo.regenerate_issues(@project, github_client)
       #milestone = find_milestone(repo) if milestone_filtered?
       #update_issue_map(all_issues(repo, milestone),repo) if !milestone_filtered? || milestone
     end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -5,13 +5,12 @@ class IssuesController < ApplicationController
   before_action :get_milestones
 
   def index
-    # this is kind of ugly but it works
-    @issue_map = {}
     @project.repositories.each do |repo|
-      milestone = find_milestone(repo) if milestone_filtered?
-      update_issue_map(all_issues(repo, milestone),repo) if !milestone_filtered? || milestone
+      repo.regenerate_issues(github_client)
+      #milestone = find_milestone(repo) if milestone_filtered?
+      #update_issue_map(all_issues(repo, milestone),repo) if !milestone_filtered? || milestone
     end
-    @issues = @project.issues.where( :gh_id => @issue_map.values.collect {| each | each[:issue].id} )
+    @issues = @project.issues
 
     if params[:labels]
       @labels = params[:labels].split(",")

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,9 @@
+class OrganizationsController < ApplicationController
+  def regenerate_users
+    organization = Organization.find(params[:id])
+    organization.regenerate_users(github_client)
+    organization.updated_at = Time.now
+    organization.save
+    redirect_to :back, notice: "Refreshed user list"
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -68,7 +68,11 @@ class ProjectsController < ApplicationController
   def add_users
     @repos = @project.repositories
     current_user.regenerate_organizations(github_client)
-    @organizations = @project.organizations(github_client)
+    # TODO: do this block at a sensible time! not every time
+    current_user.organizations.each do |o|
+      o.regenerate_users(github_client)
+    end
+    @organizations = current_user.organizations
   end
 
   def add_user

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -67,6 +67,7 @@ class ProjectsController < ApplicationController
 
   def add_users
     @repos = @project.repositories
+    current_user.regenerate_organizations(github_client)
     @organizations = @project.organizations(github_client)
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    @detailed_users = @project.detailed_users(github_client)
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -66,10 +66,14 @@ class ProjectsController < ApplicationController
 
   def add_users
     @repos = @project.repositories
-    current_user.regenerate_organizations(github_client)
+    current_user.regenerate_organizations(github_client) # fetch all gh orgs
     # TODO: do this block at a sensible time! not every time
     current_user.organizations.each do |o|
-      o.regenerate_users(github_client)
+      if o.updated_at + 2.hours < Time.now
+        o.regenerate_users(github_client)
+        o.updated_at = Time.now
+        o.save
+      end
     end
     @organizations = current_user.organizations
   end

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -1,0 +1,2 @@
+module OrganizationsHelper
+end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -4,6 +4,9 @@ class Issue < ActiveRecord::Base
   belongs_to :project
   belongs_to :repository
 
+  has_many :labels, through: :issue_labels
+  has_many :issue_labels
+
   def width
     w = super
     return 1 if w == 0 or w.nil?

--- a/app/models/issue_label.rb
+++ b/app/models/issue_label.rb
@@ -1,0 +1,4 @@
+class IssueLabel < ActiveRecord::Base
+  belongs_to :issue
+  belongs_to :label
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,6 +1,8 @@
 class Label < ActiveRecord::Base
   belongs_to :project
   belongs_to :repository
+  has_many :issues, through: :issue_labels
+  has_many :issue_labels
 
   validates :name, presence: true
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,0 +1,4 @@
+class Organization < ActiveRecord::Base
+  has_many :organization_users
+  has_many :users, through: :organization_user
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,4 @@
 class Organization < ActiveRecord::Base
+  has_many :users, through: :organization_users
   has_many :organization_users
-  has_many :users, through: :organization_user
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,4 +1,26 @@
 class Organization < ActiveRecord::Base
   has_many :users, through: :organization_users
   has_many :organization_users
+
+  def regenerate_users(gh_client)
+    gh_organization = gh_client.get(self.source)
+    gh_members = gh_client.get(gh_organization.rels[:members].href)
+
+    next_request = gh_client.last_response.rels[:next]
+    while gh_members.size && next_request
+      req = next_request.get
+      gh_members += req.data
+      next_request = req.rels[:next]
+    end
+
+    gh_members.each do |m|
+      user = InvitedUser.find_or_create_by(nickname: m.login)
+      user.image = m.rels[:avatar].href
+
+      if !user.organizations.include? self
+        user.organizations << self
+      end
+      user.save
+    end
+  end
 end

--- a/app/models/organization_user.rb
+++ b/app/models/organization_user.rb
@@ -1,0 +1,4 @@
+class OrganizationUser < ActiveRecord::Base
+  belongs_to :organization
+  belongs_to :user
+end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -1,10 +1,47 @@
 class Repository < ActiveRecord::Base
   belongs_to :project
+  belongs_to :user
   has_many :labels
+  has_many :issues
 
   validates :slug, presence: true
 
   def name
     slug
+  end
+
+  def labels_in_repo
+    labels.collect(&:name).join(',')
+  end
+
+  def regenerate_issues(github_client)
+    issues = github_client.list_issues(self.slug, per_page: 100)
+
+    next_request = github_client.last_response.rels[:next]
+    while next_request do
+      req = next_request.get
+      issues +=  req.data
+      next_request = req.rels[:next]
+    end
+
+    # now persist all the issues we got
+    issues.each do |i|
+      issue = Issue.find_or_create_by(gh_id: i.id)
+      # copy data from the API into our issue
+      issue.assignee = i.try(:assignee).try(:login)
+      issue.title = i.title
+      issue.comments_count = i.comments.to_i
+      issue.source = i.rels[:html].href
+      issue.labels = i.labels.collect(&:name).join(",")
+
+      if issue.assignee # try to associate it to a copy of our user object, if such an object exists
+        user = User.find_by_nickname(issue.assignee)
+        if user
+          user.issues << issue
+        end
+      end
+      issue.save
+      user.save if user
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ActiveRecord::Base
     gh_orgs.each do |o|
       organization = Organization.find_or_create_by(gh_id: o.id)
       organization.avatar = o.rels[:avatar].href
-      organization.source = o.rels[:html].href
+      organization.source = o.rels[:self].href
       organization.name = o.login
 
       if !organization.users.include? self

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ActiveRecord::Base
 
   has_many :project_users
   has_many :projects, through: :project_users
+  has_many :repositories
+  has_many :issues
 
   def self.find_for_github_auth(auth)
     where(auth.slice(:provider,:uid)).first_or_initialize.tap do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ActiveRecord::Base
   has_many :projects, through: :project_users
   has_many :repositories
   has_many :issues
+  has_many :organization_users
+  belongs_to :organization
 
   def self.find_for_github_auth(auth)
     where(auth.slice(:provider,:uid)).first_or_initialize.tap do |user|

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -30,14 +30,14 @@
       - col = 1
       - row = 1
       - @issues.each do |i|
-        - meta = i.labels.split(",") + [i.assignee, i.title]
+        - meta = i.labels.collect(&:name) + [i.assignee, i.title]
         - meta.compact!
         - repo = i.repository
 
         %li{class: "local-filterable portlet issue-repo-#{@project.repositories.index(repo) % 10}", "data-col" => i.col, "data-row" => i.row, "data-sizex" => i.width, "data-sizey" => i.height, :id => i.id, "data-meta" => meta }
           %div{:class => "issue-label-container #{'expanded' if @project.display_labels}"}
-            / - i.labels.split(",").each do |label|
-            /   .issue-label{:style => "background-color:##{label.color};", :title => label.name}= label.name
+            - i.labels.each do |label|
+              .issue-label{:style => "background-color:##{label.color};", :title => label.name}= label.name
           .portlet-header
             - if i.assignee
               .issue-assignee{"data-username" => i.assignee}

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -42,7 +42,8 @@
             - if i.assignee
               .issue-assignee{"data-username" => i.assignee}
                 %a{:href => "https://github.com/#{i.assignee}", :target => "_blank", :title => i.assignee}
-                  / %img.eightfoot-avatar{:alt => user.login, :src => user.rels[:avatar].href}/
+                  - user = User.find_by_nickname(i.assignee)
+                  %img.eightfoot-avatar{:alt => i.assignee, :src => user.image}
             %span
               %span.issue-link
                 %a{:href => i.source, :target => "_blank"}
@@ -51,9 +52,6 @@
                 %a.comments-link{:href => i.source, :target => "_blank"}
                   %i.fa.fa-comments-o
                   = i.comments_count
-              / - if pr_url = pull_request_url(i)
-              /   %a.pr-link{:href => pull_request_changes_url(pr_url), :target => "_blank"}
-              /     %i.fa.fa-code-fork
               %span.issue-title
                 = i.title
 - else

--- a/app/views/issues/index.html.haml
+++ b/app/views/issues/index.html.haml
@@ -29,33 +29,31 @@
     %ul.gridster-data.local-filterable{"data-filtered-by" => "issues"}
       - col = 1
       - row = 1
-      - @issues.each do |issue|
-        - hash = @issue_map[issue.id]
-        - i = hash[:issue]
-        - repo = hash[:repo]
-        - meta = i.labels.collect(&:name) + [i.try(:assignee).try(:login), i.title]
+      - @issues.each do |i|
+        - meta = i.labels.split(",") + [i.assignee, i.title]
         - meta.compact!
+        - repo = i.repository
 
-        %li{class: "local-filterable portlet issue-repo-#{@project.repositories.index(repo) % 10}", "data-col" => issue.col, "data-row" => issue.row, "data-sizex" => issue.width, "data-sizey" => issue.height, :id => issue.id, "data-meta" => meta }
+        %li{class: "local-filterable portlet issue-repo-#{@project.repositories.index(repo) % 10}", "data-col" => i.col, "data-row" => i.row, "data-sizex" => i.width, "data-sizey" => i.height, :id => i.id, "data-meta" => meta }
           %div{:class => "issue-label-container #{'expanded' if @project.display_labels}"}
-            - i.labels.each do |label|
-              .issue-label{:style => "background-color:##{label.color};", :title => label.name}= label.name
+            / - i.labels.split(",").each do |label|
+            /   .issue-label{:style => "background-color:##{label.color};", :title => label.name}= label.name
           .portlet-header
-            - if user =  i.try(:assignee)
-              .issue-assignee{"data-username" => user.login}
-                %a{:href => "https://github.com/#{user.login}", :target => "_blank", :title => user.login}
-                  %img.eightfoot-avatar{:alt => user.login, :src => user.rels[:avatar].href}/
+            - if i.assignee
+              .issue-assignee{"data-username" => i.assignee}
+                %a{:href => "https://github.com/#{i.assignee}", :target => "_blank", :title => i.assignee}
+                  / %img.eightfoot-avatar{:alt => user.login, :src => user.rels[:avatar].href}/
             %span
               %span.issue-link
-                %a{:href => i.rels[:html].href, :target => "_blank"}
+                %a{:href => i.source, :target => "_blank"}
                   %i.fa.fa-external-link
-              - if i.comments.to_i > 0
-                %a.comments-link{:href => i.rels[:html].href, :target => "_blank"}
+              - if i.comments_count > 0
+                %a.comments-link{:href => i.source, :target => "_blank"}
                   %i.fa.fa-comments-o
-                  = i.comments
-              - if pr_url = pull_request_url(i)
-                %a.pr-link{:href => pull_request_changes_url(pr_url), :target => "_blank"}
-                  %i.fa.fa-code-fork
+                  = i.comments_count
+              / - if pr_url = pull_request_url(i)
+              /   %a.pr-link{:href => pull_request_changes_url(pr_url), :target => "_blank"}
+              /     %i.fa.fa-code-fork
               %span.issue-title
                 = i.title
 - else

--- a/app/views/projects/add_users.html.haml
+++ b/app/views/projects/add_users.html.haml
@@ -11,6 +11,7 @@
     .organization-avatar
       %img{src: org.avatar}
     %h3= org.name
+    = link_to 'Refresh users', regenerate_users_organization_path(org)
     %input.local-filter{type: "text", "data-filter-for" => 'users', placeholder: "Quick filter users"}
   %ul.user-list.local-filterable{"data-filtered-by" => "users"}
     - org.users.each do |user|

--- a/app/views/projects/add_users.html.haml
+++ b/app/views/projects/add_users.html.haml
@@ -8,10 +8,10 @@
 %h2 People from your organizations:
 - @organizations.each do |org|
   .organization-header
-    %a.organization-avatar{href: org.rels[:html].href, target: "_blank"}
-      %img{src: org.rels[:avatar].href}
-    %h3= org.login
+    .organization-avatar
+      %img{src: org.avatar}
+    %h3= org.name
     %input.local-filter{type: "text", "data-filter-for" => 'users', placeholder: "Quick filter users"}
   %ul.user-list.local-filterable{"data-filtered-by" => "users"}
-    - org.members.each do |user|
+    - org.users.each do |user|
       = render partial: 'shared/user_tile', locals: {user: user, add_button: true, remove_button: false}

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -49,7 +49,7 @@
     Display Labels: #{@project.display_labels}
 %h2 Users with access to this project:
 %ul.user-list.local-filterable
-  - @detailed_users.each do |user|
+  - @project.users.each do |user|
     = render partial: 'shared/user_tile', locals: {user: user, remove_button: true, add_button: false}
 
 = link_to 'Add Users', add_users_project_path(@project)

--- a/app/views/shared/_user_tile.html.haml
+++ b/app/views/shared/_user_tile.html.haml
@@ -1,11 +1,11 @@
-%li.user-tile{data: {meta: [user.login]}}
+%li.user-tile{data: {meta: [user.nickname]}}
   .user-avatar
-    %img{src: user.rels[:avatar].href}
-    - if current_user.nickname != user.login
+    %img{src: user.image}
+    - if current_user.nickname != user.nickname
       .user-add-remove-controls
         - if add_button
-          %i.fa.fa-plus-square.user-add-button.button{data: {username: user.login}}
+          %i.fa.fa-plus-square.user-add-button.button{data: {username: user.nickname}}
         - if remove_button
-          %i.fa.fa-minus-square.user-remove-button.button{data: {username: user.login}}
+          %i.fa.fa-minus-square.user-remove-button.button{data: {username: user.nickname}}
   %span.user-login
-    %a{href: user.rels[:html].href, target: "_blank"}= user.login
+    %a{href: "https://github.com/#{user.nickname}", target: "_blank"}= user.nickname

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,12 @@ Eightfoot::Application.routes.draw do
     end
   end
 
+  resources :organizations do
+    member do
+      get 'regenerate_users'
+    end
+  end
+
   get 'updates' => 'updates#index'
 
   devise_for :users, controllers: {omniauth_callbacks: 'users/omniauth_callbacks'}

--- a/db/migrate/20140330203727_add_fields_to_issues.rb
+++ b/db/migrate/20140330203727_add_fields_to_issues.rb
@@ -1,0 +1,9 @@
+class AddFieldsToIssues < ActiveRecord::Migration
+  def change
+    add_reference :issues, :user, index: true
+    add_column :issues, :assignee, :string
+    add_column :issues, :source, :string
+    add_column :issues, :comments_count, :int
+    add_column :issues, :title, :string
+  end
+end

--- a/db/migrate/20140330212230_add_labels_to_issue.rb
+++ b/db/migrate/20140330212230_add_labels_to_issue.rb
@@ -1,0 +1,5 @@
+class AddLabelsToIssue < ActiveRecord::Migration
+  def change
+    add_column :issues, :labels, :text
+  end
+end

--- a/db/migrate/20140330213744_add_color_to_issue.rb
+++ b/db/migrate/20140330213744_add_color_to_issue.rb
@@ -1,0 +1,5 @@
+class AddColorToIssue < ActiveRecord::Migration
+  def change
+    add_column :labels, :color, :string
+  end
+end

--- a/db/migrate/20140330214132_remove_labels_column_from_issues.rb
+++ b/db/migrate/20140330214132_remove_labels_column_from_issues.rb
@@ -1,0 +1,5 @@
+class RemoveLabelsColumnFromIssues < ActiveRecord::Migration
+  def change
+    remove_column :issues, :labels
+  end
+end

--- a/db/migrate/20140330214705_create_issues_labels.rb
+++ b/db/migrate/20140330214705_create_issues_labels.rb
@@ -1,0 +1,8 @@
+class CreateIssuesLabels < ActiveRecord::Migration
+  def change
+    create_table :issue_labels do |t|
+      t.references :issue, index: true
+      t.references :label, index: true
+    end
+  end
+end

--- a/db/migrate/20140331051917_create_organizations.rb
+++ b/db/migrate/20140331051917_create_organizations.rb
@@ -1,0 +1,11 @@
+class CreateOrganizations < ActiveRecord::Migration
+  def change
+    create_table :organizations do |t|
+      t.string :avatar
+      t.string :source
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20140331051952_create_organization_users.rb
+++ b/db/migrate/20140331051952_create_organization_users.rb
@@ -1,0 +1,8 @@
+class CreateOrganizationUsers < ActiveRecord::Migration
+  def change
+    create_table :organization_users do |t|
+      t.references :organization, index: true
+      t.references :user, index: true
+    end
+  end
+end

--- a/db/migrate/20140331052654_add_ghid_to_organizations.rb
+++ b/db/migrate/20140331052654_add_ghid_to_organizations.rb
@@ -1,0 +1,6 @@
+class AddGhidToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :gh_id, :integer, :limit => 8
+    add_index :organizations, [:gh_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,21 +11,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140320205346) do
+ActiveRecord::Schema.define(version: 20140330212230) do
 
   create_table "issues", force: true do |t|
     t.integer "repository_id"
     t.integer "project_id"
-    t.integer "gh_id",         limit: 8
+    t.integer "gh_id",          limit: 8
     t.integer "row"
     t.integer "col"
     t.integer "width"
     t.integer "height"
+    t.integer "user_id"
+    t.string  "assignee"
+    t.string  "source"
+    t.integer "comments_count"
+    t.string  "title"
+    t.text    "labels"
   end
 
   add_index "issues", ["project_id", "gh_id"], name: "index_issues_on_project_id_and_gh_id", using: :btree
   add_index "issues", ["project_id"], name: "index_issues_on_project_id_and_position", using: :btree
   add_index "issues", ["repository_id"], name: "index_issues_on_repository_id", using: :btree
+  add_index "issues", ["user_id"], name: "index_issues_on_user_id", using: :btree
 
   create_table "labels", force: true do |t|
     t.string   "name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140330212230) do
+ActiveRecord::Schema.define(version: 20140330214705) do
 
   create_table "issues", force: true do |t|
     t.integer "repository_id"
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 20140330212230) do
     t.string  "source"
     t.integer "comments_count"
     t.string  "title"
-    t.text    "labels"
   end
 
   add_index "issues", ["project_id", "gh_id"], name: "index_issues_on_project_id_and_gh_id", using: :btree
@@ -34,11 +33,20 @@ ActiveRecord::Schema.define(version: 20140330212230) do
   add_index "issues", ["repository_id"], name: "index_issues_on_repository_id", using: :btree
   add_index "issues", ["user_id"], name: "index_issues_on_user_id", using: :btree
 
+  create_table "issue_labels", force: true do |t|
+    t.integer "issue_id"
+    t.integer "label_id"
+  end
+
+  add_index "issue_labels", ["issue_id"], name: "index_issue_labels_on_issue_id", using: :btree
+  add_index "issue_labels", ["label_id"], name: "index_issue_labels_on_label_id", using: :btree
+
   create_table "labels", force: true do |t|
     t.string   "name"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "repository_id"
+    t.string   "color"
   end
 
   create_table "last_edits", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140330214705) do
+ActiveRecord::Schema.define(version: 20140331052654) do
+
+  create_table "issue_labels", force: true do |t|
+    t.integer "issue_id"
+    t.integer "label_id"
+  end
+
+  add_index "issue_labels", ["issue_id"], name: "index_issue_labels_on_issue_id", using: :btree
+  add_index "issue_labels", ["label_id"], name: "index_issue_labels_on_label_id", using: :btree
 
   create_table "issues", force: true do |t|
     t.integer "repository_id"
@@ -33,14 +41,6 @@ ActiveRecord::Schema.define(version: 20140330214705) do
   add_index "issues", ["repository_id"], name: "index_issues_on_repository_id", using: :btree
   add_index "issues", ["user_id"], name: "index_issues_on_user_id", using: :btree
 
-  create_table "issue_labels", force: true do |t|
-    t.integer "issue_id"
-    t.integer "label_id"
-  end
-
-  add_index "issue_labels", ["issue_id"], name: "index_issue_labels_on_issue_id", using: :btree
-  add_index "issue_labels", ["label_id"], name: "index_issue_labels_on_label_id", using: :btree
-
   create_table "labels", force: true do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -54,6 +54,25 @@ ActiveRecord::Schema.define(version: 20140330214705) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "organization_users", force: true do |t|
+    t.integer "organization_id"
+    t.integer "user_id"
+  end
+
+  add_index "organization_users", ["organization_id"], name: "index_organization_users_on_organization_id", using: :btree
+  add_index "organization_users", ["user_id"], name: "index_organization_users_on_user_id", using: :btree
+
+  create_table "organizations", force: true do |t|
+    t.string   "avatar"
+    t.string   "source"
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "gh_id",      limit: 8
+  end
+
+  add_index "organizations", ["gh_id"], name: "index_organizations_on_gh_id", using: :btree
 
   create_table "project_labels", force: true do |t|
     t.integer  "label_id"

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe OrganizationsController do
+
+end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -1,0 +1,9 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :organization do
+    avatar "MyString"
+    source "MyString"
+    name "MyString"
+  end
+end

--- a/spec/helpers/organizations_helper_spec.rb
+++ b/spec/helpers/organizations_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrganizationsHelper. For example:
+#
+# describe OrganizationsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+describe OrganizationsHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Organization do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Branches off `team-concept`

Attempting to make it possible to store the state of affairs in the database, rather than having to paginate things and perma-cache all GitHub API responses

Starting with Issues, then moving onto Users

TODO:
- [ ] issue shouldn't belong to Project, probably should be through a `project_issues` table
- [ ] only call `regenerate_` at sensible times (when repo is added to project, after a webhook tells us that resource is stale).  Does this mean we have to keep state of "dirty" or not in the table itself?  Perhaps base this regeneration on the `last_updated_at`?
- [ ] add webhooks (since we can't regenerate smartly without this)
- [ ] re-add filters I broke to Issues (milestone, label) since we were using the GitHub API to filter for us
